### PR TITLE
Add Composer, Tests and make PSR-2 compliant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: php
+
+php:
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+
+env:
+  global:
+    - setup=basic
+
+matrix:
+  include:
+    - php: 5.6
+      env: setup=lowest
+
+sudo: false
+
+before_install:
+  - travis_retry composer self-update
+
+install:
+  - if [[ $setup = 'basic' ]]; then travis_retry composer install --no-interaction --prefer-dist; fi
+  - if [[ $setup = 'lowest' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-lowest --prefer-stable; fi
+
+script: vendor/bin/phpcs --standard=PSR2 src && vendor/bin/phpunit --coverage-text

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing Guidelines
+
+* Fork the project.
+* Make your feature addition or bug fix.
+* Add tests for it. This is important so I don't break it in a future version unintentionally.
+* Commit just the modifications, do not mess with the composer.json or CHANGELOG.md files.
+* Ensure your code is nicely formatted in the [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
+  style and that all tests pass.
+* Send the pull request.
+* Check that the Travis CI build passed. If not, rinse and repeat.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,45 @@
+{
+    "name": "mbrowne/omnipay-iats",
+    "type": "library",
+    "description": "iATS gateway for Omnipay payment processing library",
+    "keywords": [
+        "gateway",
+        "merchant",
+        "omnipay",
+        "pay",
+        "payment",
+        "iats",
+        "purchase"
+    ],
+    "homepage": "https://github.com/mbrowne/omnipay-iats",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Matt Browne",
+            "email": "email@example.com"
+        },
+        {
+            "name": "Omnipay Contributors",
+            "homepage": "https://github.com/mbrowne/omnipay-iats/contributors"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "Omnipay\\iATS\\": "src/"
+        }
+    },
+    "require": {
+        "omnipay/common": "~3.0",
+        "iatspayments/php": "^2.1"
+    },
+    "require-dev": {
+        "omnipay/tests": "~3.0",
+        "squizlabs/php_codesniffer": "~3.0"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0.x-dev"
+        }
+    },
+    "prefer-stable": true
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false">
+    <testsuites>
+        <testsuite name="Omnipay Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -27,7 +27,7 @@ class Gateway extends AbstractGateway
             'testMode' => false,
         );
     }
-	
+    
     public function setAgentCode($value)
     {
         return $this->setParameter('agentCode', $value);
@@ -37,7 +37,7 @@ class Gateway extends AbstractGateway
     {
         return $this->getParameter('agentCode');
     }
-	
+    
     public function setPassword($value)
     {
         return $this->setParameter('password', $value);
@@ -47,8 +47,9 @@ class Gateway extends AbstractGateway
     {
         return $this->getParameter('password');
     }
-	
-	public function purchase(array $parameters = array()) {
-		return $this->createRequest('\Omnipay\iATS\Message\PurchaseRequest', $parameters);
-	}
+
+    public function purchase(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\iATS\Message\PurchaseRequest', $parameters);
+    }
 }

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -9,10 +9,10 @@ use iATS;
  */
 class PurchaseRequest extends AbstractRequest
 {
-	//Test user ID and password from http://home.iatspayments.com/developers/test-credentials,
-	//used when testMode is enabled.
-	public $testUser = 'TEST88';
-	public $testPassword = 'TEST88';
+    //Test user ID and password from http://home.iatspayments.com/developers/test-credentials,
+    //used when testMode is enabled.
+    public $testUser = 'TEST88';
+    public $testPassword = 'TEST88';
 
     public function setAgentCode($value)
     {
@@ -23,7 +23,7 @@ class PurchaseRequest extends AbstractRequest
     {
         return $this->getParameter('agentCode');
     }
-	
+    
     public function setPassword($value)
     {
         return $this->setParameter('password', $value);
@@ -36,57 +36,57 @@ class PurchaseRequest extends AbstractRequest
 
     public function getData()
     {
-		$this->validate('amount', 'card');
-		$card = $this->getCard();
-		$card->validate();
-		
-		// Create and populate the request object.
-		$data = array(
-		  'recurring' => FALSE,
-		  'mop' => $this->iatsCreditCardMop($card->getBrand()), //method of payment (Visa, Mastercard, etc.)
-		  'customerIPAddress' => $_SERVER['REMOTE_ADDR'],
-		  'firstName' => $card->getFirstName(),
-		  'lastName' => $card->getLastName(),
-		  'companyName' => $card->getCompany(),
-		  'address' => $card->getBillingAddress1(). "\n". $card->getBillingAddress2(),
-		  'city' => $card->getBillingCity(),
-		  'state' => $card->getBillingState(),
-		  'zipCode' => $card->getBillingPostcode(),
-		  'country' => $card->getBillingCountry(),
-		  'phone' => $card->getPhone(),
-		  'email' => $card->getEmail(),
-		  'total' => $this->getAmount(),
-		  'creditCardNum' => $card->getNumber(),
-		  'creditCardExpiry' => $card->getExpiryDate('m').'/'.$card->getExpiryDate('y'),
-		  'cvv2' => $card->getCvv(),
-		  'currency' => $this->getCurrency()
-		);		
-		return $data;
+        $this->validate('amount', 'card');
+        $card = $this->getCard();
+        $card->validate();
+        
+        // Create and populate the request object.
+        $data = array(
+          'recurring' => false,
+          'mop' => $this->iatsCreditCardMop($card->getBrand()), //method of payment (Visa, Mastercard, etc.)
+          'customerIPAddress' => $this->getClientIp(),
+          'firstName' => $card->getFirstName(),
+          'lastName' => $card->getLastName(),
+          'companyName' => $card->getCompany(),
+          'address' => $card->getBillingAddress1(). "\n". $card->getBillingAddress2(),
+          'city' => $card->getBillingCity(),
+          'state' => $card->getBillingState(),
+          'zipCode' => $card->getBillingPostcode(),
+          'country' => $card->getBillingCountry(),
+          'phone' => $card->getPhone(),
+          'email' => $card->getEmail(),
+          'total' => $this->getAmount(),
+          'creditCardNum' => $card->getNumber(),
+          'creditCardExpiry' => $card->getExpiryDate('m').'/'.$card->getExpiryDate('y'),
+          'cvv2' => $card->getCvv(),
+          'currency' => $this->getCurrency()
+        );
+        return $data;
     }
-	
-	/**
-	 * Converts an Omnipay credit card type to an iATS-compatible credit card type ("method of payment" or MOP).
-	 */
-	private function iatsCreditCardMop($type) {
-		$mop = array(
-		  'visa' => 'VISA',
-		  'mastercard' => 'MC',
-		  'amex' => 'AMX',
-		  'discover' => 'DSC',
-		);
-		return $mop[$type];
-	}
+    
+    /**
+     * Converts an Omnipay credit card type to an iATS-compatible credit card type ("method of payment" or MOP).
+     */
+
+    private function iatsCreditCardMop($type)
+    {
+        $mop = array(
+          'visa' => 'VISA',
+          'mastercard' => 'MC',
+          'amex' => 'AMX',
+          'discover' => 'DSC',
+        );
+        return $mop[$type];
+    }
 
     public function sendData($data)
     {
-		if ($this->getTestMode()) {
-			//Use test credentials from http://home.iatspayments.com/developers/test-credentials
-			$processLink = new iATS\ProcessLink($this->testUser, $this->testPassword);
-		}
-		else {
-			$processLink = new iATS\ProcessLink($this->getAgentCode(), $this->getPassword());
-		}
-        $result = $processLink->processCreditCard($data);		
+        $agentCode = $this->getTestMode() ? $this->testUser : $this->getAgentCode();
+        $password = $this->getTestMode() ? $this->testPassword : $this->getPassword();
+        
+        $newLink = new iATS\ProcessLink($agentCode, $password);
+
+        $result = $newLink->processCreditCard($data);
         return $this->response = new PurchaseResponse($this, $result);
     }
 

--- a/src/Message/PurchaseResponse.php
+++ b/src/Message/PurchaseResponse.php
@@ -1,8 +1,8 @@
 <?php
 namespace Omnipay\iATS\Message;
 
-use Omnipay\Common\Message\AbstractResponse,
-	Omnipay\Common\Message\RequestInterface;
+use Omnipay\Common\Message\AbstractResponse;
+use Omnipay\Common\Message\RequestInterface;
 
 /**
  * iATS Authorize Response
@@ -14,23 +14,40 @@ class PurchaseResponse extends AbstractResponse
         $this->request = $request;
         $this->data = $data;
     }
-	
-	function isSuccessful() {
-		return (strpos(trim($this->data['AUTHORIZATIONRESULT']), 'OK') === 0);
-	}
-	
-	function getMessage() {
-		if (is_string($this->data)) {
-			return $this->data;
-		}
-		return false;
-	}
-	
-	function getTransactionId() {
-		return $this->data['TRANSACTIONID'];
-	}
-	
-	function getCustomerCode() {
-		return $this->data['CUSTOMERCODE'];
-	}
+    
+    public function isSuccessful()
+    {
+        if (is_string($this->data) || !$this->data['AUTHORIZATIONRESULT']) {
+            return false;
+        }
+
+        return (strpos(trim($this->data['AUTHORIZATIONRESULT']), 'OK') === 0);
+    }
+    
+    public function getMessage()
+    {
+        if ($this->isSuccessful()) {
+            return null;
+        }
+
+        return $this->data;
+    }
+    
+    public function getTransactionId()
+    {
+        if (!$this->isSuccessful() || !$this->data['TRANSACTIONID']) {
+            return null;
+        }
+
+        return $this->data['TRANSACTIONID'];
+    }
+    
+    public function getCustomerCode()
+    {
+        if (!$this->isSuccessful() || !$this->data['CUSTOMERCODE']) {
+            return null;
+        }
+
+        return $this->data['CUSTOMERCODE'];
+    }
 }

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Omnipay\iATS;
+
+use Omnipay\Omnipay;
+use Omnipay\iATS\Message\PurchaseRequest;
+use Omnipay\Tests\GatewayTestCase;
+
+class GatewayTest extends GatewayTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->gateway = Omnipay::create('iATS');
+        $this->gateway->initialize(['testMode'  => true]);   
+    }
+
+    public function testPurchase()
+    {
+        $options = array(
+            'amount' => '10.00',
+            'card' => $this->getValidCard(),
+        );
+        $request = $this->gateway->purchase($options);
+
+        $this->assertInstanceOf('\Omnipay\iATS\Message\PurchaseRequest', $request);
+        $this->assertArrayHasKey('total', $request->getData());
+    }
+}

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Omnipay\iATS\Message;
+
+use Omnipay\Omnipay;
+use Omnipay\iATS\Gateway;
+use Omnipay\Tests\TestCase;
+
+class PurchaseRequestTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->gateway = Omnipay::create('iATS');
+        $this->gateway->initialize(['testMode'  => true]);
+    }
+
+    public function testCreditCardSuccess()
+    {
+        // card numbers ending in even number should be successful
+        $options = array(
+            'amount' => '10.00',
+            'currency' => 'CAD',
+            'card' => $this->getValidCard(),
+        );
+        $options['card']['number'] = '4111111111111111';
+        $options['card']['cvv'] = '111';
+
+        $response = $this->gateway->purchase($options)->send();
+
+        $this->assertInstanceOf('\Omnipay\iATS\Message\PurchaseResponse', $response);
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNotEmpty($response->getTransactionId());
+        $this->assertEmpty($response->getMessage());
+    }
+
+    public function testCreditCardFailure()
+    {
+        // card numbers ending in odd number should be declined
+        $options = array(
+            'amount' => '10.00',
+            'card' => $this->getValidCard(),
+        );
+        $options['card']['number'] = '4111111111111111';
+        $options['card']['cvv'] = '112';
+
+        $response = $this->gateway->purchase($options)->send();
+
+        $this->assertInstanceOf('\Omnipay\iATS\Message\PurchaseResponse', $response);
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertEmpty($response->getTransactionId());
+        $this->assertSame("Service cannot be used with this Method of Payment or Currency.", $response->getMessage());
+    }
+}

--- a/tests/Message/PurchaseResponseTest.php
+++ b/tests/Message/PurchaseResponseTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Omnipay\iATS\Message;
+
+use Omnipay\Tests\TestCase;
+
+class ResponseTest extends TestCase
+{
+    public function testSuccess()
+    {
+        $response = new PurchaseResponse(
+            $this->getMockRequest(),
+            array('TRANSACTIONID' => 'abc123', 'CUSTOMERCODE' => '123', 'AUTHORIZATIONRESULT' => 'OK')
+        );
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame('abc123', $response->getTransactionId());
+        $this->assertSame('123', $response->getCustomerCode());
+        $this->assertEmpty($response->getMessage());
+    }
+
+    public function testFailure()
+    {
+        $mockErrorMessage = "Credit card is invalid.";
+
+        $response = new PurchaseResponse(
+            $this->getMockRequest(),
+            $mockErrorMessage
+        );
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertEmpty($response->getTransactionId());
+        $this->assertEmpty($response->getCustomerCode());
+        $this->assertSame($mockErrorMessage, $response->getMessage());
+    }
+}


### PR DESCRIPTION
This adds `composer.json` which requires the iATS php api, and some basic unit testing. This also formats the code to be PSR-2 compliant, so most of the changes are just whitespace.

Code wise, I did do some changes to the `PurchaseResponse` code to prevent some `Implicit string offset` warnings.

Oh also @mbrowne I didn't include your email under the author section for `composer.json`. I think that was required for the Travis CI tests, so you'd want to fill that in.